### PR TITLE
ADD - RequestModifier, to provide low-level request modification. Exa…

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,35 @@ proxyOptions.Reporter = r => {
 };
 ```
 
+#### Request Modifier
+
+`Action<HttpContext, HttpClient> RequestModifier`: provides more low level access for modifying the proxied request. 
+
+For example: 
+
+- When you want to inject `Bearer` token in multi-services scenario without exposing the token to client's  Javascript.
+
+Here's an example of usage:
+
+```csharp
+new ProxyRule {
+    // ...
+    Modifier = (req, user) => {
+        req.RequestUri = new Uri(
+            $"https://protected-backend.com{req.RequestUri.PathAndQuery}"
+        );
+    },
+    RequestModifier = async (ctx, client) =>
+    {
+        var user = ctx.User;
+		if(user != null && user.Identity.IsAuthenticated)
+		{
+		    var accessToken = await context.GetTokenAsync("access_token");
+			client.SetBearerToken(accessToken);
+		}
+    }
+}
+```
 
 And that's it!
 

--- a/README.md
+++ b/README.md
@@ -167,36 +167,6 @@ proxyOptions.Reporter = r => {
 };
 ```
 
-#### Request Modifier
-
-`Action<HttpContext, HttpClient> RequestModifier`: provides more low level access for modifying the proxied request. 
-
-For example: 
-
-- When you want to inject `Bearer` token in multi-services scenario without exposing the token to client's  Javascript.
-
-Here's an example of usage:
-
-```csharp
-new ProxyRule {
-    // ...
-    Modifier = (req, user) => {
-        req.RequestUri = new Uri(
-            $"https://protected-backend.com{req.RequestUri.PathAndQuery}"
-        );
-    },
-    RequestModifier = async (ctx, client) =>
-    {
-        var user = ctx.User;
-		if(user != null && user.Identity.IsAuthenticated)
-		{
-		    var accessToken = await context.GetTokenAsync("access_token");
-			client.SetBearerToken(accessToken);
-		}
-    }
-}
-```
-
 And that's it!
 
 Heavily inspired by https://github.com/aspnet/Proxy

--- a/src/SharpReverseProxy/ProxyMiddleware.cs
+++ b/src/SharpReverseProxy/ProxyMiddleware.cs
@@ -40,6 +40,7 @@ namespace SharpReverseProxy {
             SetProxyRequestBody(proxyRequest, context);
             SetProxyRequestHeaders(proxyRequest, context);
 
+            matchedRule.RequestModifier.Invoke(context, _httpClient);
             matchedRule.Modifier.Invoke(proxyRequest, context.User);
             proxyRequest.Headers.Host = proxyRequest.RequestUri.Host;
 

--- a/src/SharpReverseProxy/ProxyMiddleware.cs
+++ b/src/SharpReverseProxy/ProxyMiddleware.cs
@@ -40,8 +40,7 @@ namespace SharpReverseProxy {
             SetProxyRequestBody(proxyRequest, context);
             SetProxyRequestHeaders(proxyRequest, context);
 
-            matchedRule.RequestModifier.Invoke(context, _httpClient);
-            matchedRule.Modifier.Invoke(proxyRequest, context.User);
+            matchedRule.Modifier.Invoke(proxyRequest, context);
             proxyRequest.Headers.Host = proxyRequest.RequestUri.Host;
 
             try {

--- a/src/SharpReverseProxy/ProxyRule.cs
+++ b/src/SharpReverseProxy/ProxyRule.cs
@@ -7,10 +7,9 @@ using System.Threading.Tasks;
 namespace SharpReverseProxy {
     public class ProxyRule {
         public Func<Uri, bool> Matcher { get; set; } = uri => false;
-        public Action<HttpRequestMessage, ClaimsPrincipal> Modifier { get; set; } = (msg, user) => { };
+        public Action<HttpRequestMessage, HttpContext> Modifier { get; set; } = (msg, ctx) => { };
         public Func<HttpResponseMessage, HttpContext, Task> ResponseModifier { get; set; } = null;
         public bool PreProcessResponse { get; set; } = true;
         public bool RequiresAuthentication { get; set; }
-        public Action<HttpContext, HttpClient> RequestModifier { get; set; } = (ctx, httpClient) => { };
     }
 }

--- a/src/SharpReverseProxy/ProxyRule.cs
+++ b/src/SharpReverseProxy/ProxyRule.cs
@@ -11,5 +11,6 @@ namespace SharpReverseProxy {
         public Func<HttpResponseMessage, HttpContext, Task> ResponseModifier { get; set; } = null;
         public bool PreProcessResponse { get; set; } = true;
         public bool RequiresAuthentication { get; set; }
+        public Action<HttpContext, HttpClient> RequestModifier { get; set; } = (ctx, httpClient) => { };
     }
 }


### PR DESCRIPTION
Add RequestModifier

#### Request Modifier

`Action<HttpContext, HttpClient> RequestModifier`: provides more low level access for modifying the proxied request. 

For example: 

- When you want to inject `Bearer` token in multi-services scenario without exposing the token to client's  Javascript.

Here's an example of usage:

```csharp
new ProxyRule {
    // ...
    Modifier = (req, user) => {
        req.RequestUri = new Uri(
            $"https://protected-backend.com{req.RequestUri.PathAndQuery}"
        );
    },
    RequestModifier = async (ctx, client) =>
    {
        var user = ctx.User;
		if(user != null && user.Identity.IsAuthenticated)
		{
		    var accessToken = await context.GetTokenAsync("access_token");
			client.SetBearerToken(accessToken);
		}
    }
}
```