### PR TITLE
Add standard Forwarded header

### DIFF
--- a/src/SharpReverseProxy/ProxyMiddleware.cs
+++ b/src/SharpReverseProxy/ProxyMiddleware.cs
@@ -104,6 +104,12 @@ namespace SharpReverseProxy {
                     requestMessage.Content?.Headers.TryAddWithoutValidation(header.Key, header.Value.ToArray());
                 }
             }
+
+            if (_options.AddForwardedHeader) {
+                requestMessage.Headers.TryAddWithoutValidation("Forwarded", $"for={context.Connection.RemoteIpAddress}");
+                requestMessage.Headers.TryAddWithoutValidation("Forwarded", $"host={requestMessage.Headers.Host}");
+                requestMessage.Headers.TryAddWithoutValidation("Forwarded", string.Format("proto={0}", context.Request.IsHttps ? "https" : "http"));
+            }
         }
 
         private bool UserIsAuthenticated(HttpContext context) {

--- a/src/SharpReverseProxy/ProxyOptions.cs
+++ b/src/SharpReverseProxy/ProxyOptions.cs
@@ -10,6 +10,7 @@ namespace SharpReverseProxy {
         public Action<ProxyResult> Reporter { get; set; } = result => { };
 
         public bool FollowRedirects { get; set; } = true;
+        public bool AddForwardedHeader { get; set; } = false;
 
         public ProxyOptions() {}
 


### PR DESCRIPTION
As a proxy, it is possible to inject the RFC 7239 standard header `Forwarded`, to let the called server know who was the client who originally created the request.

I added an option to inject this header (default: false) in case someone needs it.

I did not specify the `by` section because it may not be wanted to let someone know your service IP, or (as in my case) it may not be useful to have this information when the service is behind a load balancer, since that IP would be private.

Let me know if something is not right or not useful.