### PR TITLE
Content type fix in response modification sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ new ProxyRule {
                         ),
                         RegexOptions.IgnoreCase
                     );
+                    ctx.Response.ContentType = msg.Content.Headers.ContentType?.MediaType;
                     byte[] data = Encoding.UTF8.GetBytes(body);
                     ctx.Response.ContentLength = data.Length;
                     await ctx.Response.Body.WriteAsync(data, 0, data.Length);


### PR DESCRIPTION
Before, modified files would be sent without a content type, making IE ignore them entirely.

On a different note, have you considered moving the logic of the sample into the library proper? I would kind of expect this functionality to be part of something called "reverse proxy". Not sure how flexible it would need to be though.